### PR TITLE
chore: disable unused warning

### DIFF
--- a/src/moon.pkg.json
+++ b/src/moon.pkg.json
@@ -8,5 +8,6 @@
         "path": "moonbitlang/quickcheck",
         "alias": "qc"
       }
-    ]
+    ],
+    "warn-list": "-1-2-3-5-6-7-8"
 }


### PR DESCRIPTION
Too many warnings to see the more important ones.

such as
```
    │                 ──┬──
    │                   ╰──── Warning: This method is declared as Gen::spawn, calling this kind of method directly via spawn(..) is deprecated, use qualified syntax Gen::spawn(..), or declare the method as `fn spawn(self : Gen, ..)` instead.
```